### PR TITLE
Workaround for a bug present in the Mac OS X IOHIDManagerOpen.

### DIFF
--- a/hid-mac.c
+++ b/hid-mac.c
@@ -371,14 +371,14 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 
 static int init_hid_manager(void)
 {
-	IOReturn res;
-	
 	/* Initialize all the HID Manager Objects */
 	hid_mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
-	IOHIDManagerScheduleWithRunLoop(hid_mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-	res = IOHIDManagerOpen(hid_mgr, kIOHIDOptionsTypeNone);
-	return (res == kIOReturnSuccess)? 0: -1;
+	if (hid_mgr) {
+		IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
+		IOHIDManagerScheduleWithRunLoop(hid_mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+		return 0;
+	}
+	return -1;
 }
 
 int HID_API_EXPORT hid_init(void)
@@ -414,7 +414,9 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	setlocale(LC_ALL,"");
 
 	/* Set up the HID Manager if it hasn't been done */
-	hid_init();
+	if (hid_init()) {
+		return NULL;
+	}
 	
 	/* Get a list of the Devices */
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);


### PR DESCRIPTION
Fix for a segmentation fault in cython-hidapi:
Check if hid_init exits successfully and fail cleanly if not. The side effect of the change on Line 417 is that a failure of hid_init will lead to the calling application believing that there are no HID devices connected, rather than reporting an error. The segmentation fault is only triggered by the bug in IOKit, which is also fixed in this change.

Workaround for a bug in IOKit:
If IOHIDManagerOpen is called while a keyboard or mouse is attached, it will fail with kIOReturnExclusiveAccess.
Comparing hid_init to the equivalent implementation in hidapi, it seems that hidapi doesn't call IOHIDManagerOpen, so this change ports that behaviour.